### PR TITLE
Add support for autodetecting EKS when IMDSv2 is in use

### DIFF
--- a/cmd/kubeletmein/generate.go
+++ b/cmd/kubeletmein/generate.go
@@ -55,6 +55,12 @@ func Generate(c *config.Config) *cobra.Command {
 				if err != nil {
 					return err
 				}
+			case "eks-imdsv2":
+				logger.Info("EKS using IMDSv2 detected")
+				err := eks.Generate(c)
+				if err != nil {
+					return err
+				}
 			case "autodetect":
 				logger.Debug("autodetect? We should not have got here")
 			default:

--- a/pkg/autodetect/autodetect.go
+++ b/pkg/autodetect/autodetect.go
@@ -53,7 +53,7 @@ var (
 		},
 		"eks-imdsv2": Provider{
 			Path:               "/latest/api/token",
-			Method:             "POST",
+			Method:             "PUT",
 			RequestHeader:      map[string]string{"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
 			ResponseHeader:     map[string]string{"Server": "EC2ws"},
 			ExpectedStatusCode: http.StatusOK,


### PR DESCRIPTION
The current implementation of autodetect will only successfully autodetect EKS when using version one of the Instance Metadata Service.  This pull request adds the ability for autodetect to work correctly when IMDSv2 is in use, which is default for EKS Managed Nodes, and encouraged by defaults in cfn templates for self managed nodes. 

Luckily - the AWS SDK for Go appears to seamlessly handle this (which I found out by manually specifying the provider. So it appears only the autodetect functionality needed to change.

Lastly - I am newish to Go, so please let me know if you would like any changes/adjustments to the code. I tried my best to honor the original pattern :) 


![Screen Shot 2022-06-12 at 1 12 04 PM](https://user-images.githubusercontent.com/73837129/173244947-46b06f92-b49b-4c6e-a30f-e6d6d720213c.png)



https://aws.amazon.com/about-aws/whats-new/2020/08/amazon-eks-supports-ec2-instance-metadata-service-v2/
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works